### PR TITLE
Add demo OpenManus environment

### DIFF
--- a/openmanus_rl/agentgym/agentenv-openmanus/README.md
+++ b/openmanus_rl/agentgym/agentenv-openmanus/README.md
@@ -1,0 +1,8 @@
+# OpenManus Demo Environment
+
+This package provides a minimal text environment used for
+examples and testing within OpenManus-RL. It does not rely on any
+external server. The agent succeeds by replying `finish` within a few
+steps. The environment implements the same `BaseEnvClient` interface as
+the other AgentGym environments so it can be loaded by
+`openmanus_rl.llm_agent.openmanus.OpenManusAgent`.

--- a/openmanus_rl/agentgym/agentenv-openmanus/__init__.py
+++ b/openmanus_rl/agentgym/agentenv-openmanus/__init__.py
@@ -1,0 +1,3 @@
+"""OpenManus demo environment package."""
+from .agentenv_openmanus import OpenManusEnvClient, OpenManusTask
+__all__ = ["OpenManusEnvClient", "OpenManusTask"]

--- a/openmanus_rl/agentgym/agentenv-openmanus/pyproject.toml
+++ b/openmanus_rl/agentgym/agentenv-openmanus/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "agentenv_openmanus"
+version = "0.0.1"
+description = "Simple OpenManus demo environment"
+requires-python = ">=3.9"
+readme = "README.md"
+license = {text = "MIT"}
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"

--- a/openmanus_rl/agentgym/agentenv/agentenv/envs/__init__.py
+++ b/openmanus_rl/agentgym/agentenv/agentenv/envs/__init__.py
@@ -11,3 +11,4 @@ from .todo import TodoEnvClient, TodoTask
 from .weather import WeatherEnvClient, WeatherTask
 from .webarena import WebarenaEnvClient, WebarenaTask
 from .webshop import WebshopEnvClient, WebshopTask
+from .openmanus import OpenManusEnvClient, OpenManusTask

--- a/openmanus_rl/agentgym/agentenv/agentenv/envs/openmanus.py
+++ b/openmanus_rl/agentgym/agentenv/agentenv/envs/openmanus.py
@@ -1,0 +1,67 @@
+from typing import Any, Mapping
+
+from agentenv.controller import BaseEnvClient, BaseTask, ConversationMessage, StepOutput
+
+
+class OpenManusEnvClient(BaseEnvClient):
+    """Lightweight built-in environment for demonstrations."""
+
+    conversation_start = (
+        ConversationMessage(
+            {
+                "from": "human",
+                "loss": None,
+                "value": "You are in a demo environment. Reply 'finish' to succeed.",
+            }
+        ),
+        ConversationMessage({"from": "gpt", "loss": False, "value": "Understood."}),
+    )
+
+    def __init__(self, env_server_base: str = "", data_len: int = 1, *args, timeout: int = 300, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.env_server_base = env_server_base
+        self.data_len = data_len
+        self.timeout = timeout
+        self.reset(0)
+
+    def __len__(self) -> int:
+        return self.data_len
+
+    def observe(self) -> str:
+        return self.state
+
+    def step(self, action: str) -> StepOutput:
+        if action.endswith("</s>"):
+            action = action[:-5]
+        action = action.split("Action:")[-1].strip().lower()
+        self.steps += 1
+        reward = 0.0
+        done = False
+        if "finish" in action:
+            self.state = "Task completed."
+            reward = 1.0
+            done = True
+        elif self.steps >= self.max_steps:
+            self.state = "Task failed."
+            done = True
+        else:
+            self.state = f"Received: {action}"
+        self.done = done
+        return StepOutput(state=self.state, reward=reward, done=done)
+
+    def reset(self, idx: int = 0) -> Mapping[str, Any]:
+        self.steps = 0
+        self.max_steps = 3
+        self.state = "Demo start. Reply 'finish' to end successfully."
+        self.done = False
+        return {"observation": self.state, "reward": 0.0, "done": False, "score": 0.0}
+
+
+class OpenManusTask(BaseTask):
+    env_client_cls = OpenManusEnvClient
+    env_name = "OpenManusDemo"
+
+    def __init__(self, client_args: Mapping[str, Any], *args, n_clients: int = 1, **kwargs) -> None:
+        super().__init__(client_args, n_clients, *args, **kwargs)
+
+

--- a/openmanus_rl/llm_agent/openmanus.py
+++ b/openmanus_rl/llm_agent/openmanus.py
@@ -114,6 +114,7 @@ class OpenManusAgent:
             "sciworld": "SciworldTask", "sheet": "SheetTask", "sqlgym": "SqlGymTask",
             "textcraft": "TextCraftTask", "todo": "TodoTask", "weather": "WeatherTask",
             "webarena": "WebarenaTask", "webshop": "WebshopTask",
+            "openmanusdemo": "OpenManusTask",
         }
 
         if env_name_lower not in ENV_TO_TASK_CLASS:


### PR DESCRIPTION
## Summary
- add a lightweight demo environment under `agentenv-openmanus`
- expose the environment via `agentenv.envs` and environment map
- update `OpenManusAgent` environment mapping

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*